### PR TITLE
darkestdungeon - small tweak to getExecutable to use Steam exe if present

### DIFF
--- a/game-darkestdungeon/index.js
+++ b/game-darkestdungeon/index.js
@@ -356,7 +356,7 @@ function getExecutable(discoveryPath) {
   }
 
   if ((discoveryPath === undefined) && (getDiscoveryPath() === undefined)) {
-    return STEAM_EXE;
+    return GOG_EXE; //use GOG on early return since it is present in both versions
   }
 
   const discPath = (discoveryPath !== undefined)

--- a/game-darkestdungeon/index.js
+++ b/game-darkestdungeon/index.js
@@ -365,9 +365,10 @@ function getExecutable(discoveryPath) {
 
   let execFile = GOG_EXE;
   try {
-    fs.statSync(path.join(discPath, GOG_EXE))
-  } catch (err) {
+    fs.statSync(path.join(discPath, STEAM_EXE)); //only use Steam exe if it exists
     execFile = STEAM_EXE;
+  } catch (err) {
+    //do nothing
   }
 
   return execFile;

--- a/game-darkestdungeon/info.json
+++ b/game-darkestdungeon/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Darkest Dungeon",
   "author": "Black Tree Gaming Ltd.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Support for Darkest Dungeon"
 }


### PR DESCRIPTION
Small tweak to use Steam exe if present. This will fix a minor annoyance one user was having on the forums (compatibility with WeMod).